### PR TITLE
(feature) Functionality to save screenshot.

### DIFF
--- a/inject/elements.js
+++ b/inject/elements.js
@@ -152,6 +152,7 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
             input[type=submit],
             input[type=button],
             select {
+              font-size: 12px;
               appearance: none;
               padding: 10px;
               border-radius: 8px;
@@ -161,8 +162,8 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
               cursor: pointer;
               font-weight: 500;
               box-sizing: border-box;
-              max-width: 5rem;
-              max-height: 3rem;
+              max-width: 5.2rem;
+              height: 3rem;
               display: inline;
             }
             input[type=text] {
@@ -382,8 +383,9 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
               <progress id="recognize" value="0" max="1"></progress>
             </div>
             <div id="top">
-             <span class="section-heading">OCR Text</span>  
-             <button id="save" style="display: inline;">Save</Save>
+             <span class="section-heading">OCR Text</span>
+             <button id="save-screenshot" style="display: inline;">Save Screenshot</button>
+             <button id="save-text" style="display: inline;">Save Text</button>
              <button id="close" title="${this.locales.close}"><i class="fa fa-close"></i>Close</button> 
             </div>
              <div id="result" data-msg="Please wait..." style="display:none;"></div>
@@ -774,8 +776,8 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
                   });
                 };
 
-                // save
-                this.shadowRoot.getElementById('save').onclick = e => {
+                // Save text
+                this.shadowRoot.getElementById('save-text').onclick = e => {
                   const textToSave = this.shadowRoot.getElementById('result').innerText;
               
                   // Create a blob for the OCR text
@@ -795,6 +797,23 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
                   // Remove the link from the Shadow DOM
                   this.shadowRoot.removeChild(link);
               };
+                             
+              // Save screenshot
+              this.shadowRoot.getElementById('save-screenshot').onclick = e => {
+                const url = localStorage.getItem('ocr-screenshot');
+                
+                // Create a link element
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'screenshot.png';
+                
+                // Append the link to the Shadow DOM and click it
+                this.shadowRoot.appendChild(a);
+                a.click();
+                
+                // Remove the link from the Shadow DOM
+                this.shadowRoot.removeChild(a);
+            };
                              
                 // close
                 this.shadowRoot.getElementById('close').onclick = e => {

--- a/inject/response.js
+++ b/inject/response.js
@@ -17,6 +17,9 @@
   } : (name, ...args) => em[name](...args);
 
   const ocr = (lang, src) => {
+    // store screenshot url in local storage
+    localStorage.setItem('ocr-screenshot', src);
+
     const report = report => {
       command('message', report.status);
 


### PR DESCRIPTION
# Closes #26 
- The extension now has an option to download the captured screenshot.
- Added a button for the new feature along with some formatting changes for consistency.
- Screenshot (base64 URL) is saved in local storage in `response.js` and fetched in `elements.js` when the button is clicked.

## Updated UI

![Screenshot (10)](https://github.com/gitgoap/AI-Snipping-Tool/assets/112375644/89b8b9bd-93f8-451a-b191-821580914ebd)
